### PR TITLE
[wip] customed jnlp slave image

### DIFF
--- a/src/main/resources/io/alauda/jenkins/plugins/pipeline/AlaudaDSL.groovy
+++ b/src/main/resources/io/alauda/jenkins/plugins/pipeline/AlaudaDSL.groovy
@@ -619,7 +619,9 @@ class AlaudaDSL implements Serializable {
         private AlaudaDSL alauda;
         private String imageFullName
         private String ciCredentialsId
+        private String jnlpCredentialsId
         private String ciImage
+        private String jnlpImage
         private Closure ciBody
         private String contextPath
         private String dockerfileLocation
@@ -661,6 +663,12 @@ class AlaudaDSL implements Serializable {
             this.ciCredentialsId = credentialsId
             this.ciImage = ciImage
             this.ciBody = body
+            return this
+        }
+
+        Build withJnlpImage(String jnlpImage, String credentialsId) {
+            this.jnlpCredentialsId = credentialsId
+            this.jnlpImage = jnlpImage
             return this
         }
 
@@ -776,6 +784,9 @@ class AlaudaDSL implements Serializable {
         Build startBuild(){
             this.ciEnabled = true
             String registry = AlaudaDSL.parseRegistry(ciImage)
+            if (this.jnlpImage == null || this.jnlpImage == "") {
+                this.jnlpImage = "jenkins/jnlp-slave:alpine"
+            }
 
             if(this.ciCredentialsId != null && this.ciCredentialsId != "") {
                 alauda.script.withEnv(["registry=${registry}"]) {
@@ -793,6 +804,9 @@ class AlaudaDSL implements Serializable {
                     label: label,
                     containers:[
                             alauda.script.containerTemplate(name: 'ci-container', image: "${ciImage}", ttyEnabled: true,
+                                envVars: [alauda.script.envVar(key: "LANG", value: "C.UTF-8")]),
+                            alauda.script.containerTemplate(name: 'jnlp', image: "${jnlpImage}", ttyEnabled: true,
+                                args: "${computer.jnlpmac} ${computer.name}",
                                 envVars: [alauda.script.envVar(key: "LANG", value: "C.UTF-8")])
                     ],
                     volumes: this.getVolumes()

--- a/src/main/resources/io/alauda/jenkins/plugins/pipeline/AlaudaDSL.groovy
+++ b/src/main/resources/io/alauda/jenkins/plugins/pipeline/AlaudaDSL.groovy
@@ -806,7 +806,6 @@ class AlaudaDSL implements Serializable {
                             alauda.script.containerTemplate(name: 'ci-container', image: "${ciImage}", ttyEnabled: true,
                                 envVars: [alauda.script.envVar(key: "LANG", value: "C.UTF-8")]),
                             alauda.script.containerTemplate(name: 'jnlp', image: "${jnlpImage}", ttyEnabled: true,
-                                args: "${computer.jnlpmac} ${computer.name}",
                                 envVars: [alauda.script.envVar(key: "LANG", value: "C.UTF-8")])
                     ],
                     volumes: this.getVolumes()


### PR DESCRIPTION
as https://github.com/jenkinsci/kubernetes-plugin#constraints says:

>Multiple containers can be defined in a pod. One of them is automatically created with name jnlp, and runs the Jenkins JNLP agent service, with args ${computer.jnlpmac} ${computer.name}, and will be the container acting as Jenkins agent.

try to define jnlp containerTemplate to customed jnlp slave image